### PR TITLE
Initial implementation of transforming init constructors to kotlin

### DIFF
--- a/IntegrationTest/build.sh
+++ b/IntegrationTest/build.sh
@@ -1,0 +1,22 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD=$DIR/build
+mkdir -p $BUILD
+mkdir -p $BUILD/kt
+mkdir -p $BUILD/jar
+
+set -e
+
+echo "Compiling tool..."
+xcodebuild  -workspace ../SwiftKotlin.xcworkspace -scheme SwiftKotlinCommandLine SYMROOT=$BUILD > $BUILD/xcodebuild.log
+
+echo "Compiling swift..."
+swiftc constructors.swift -o $BUILD/swiftout
+
+echo "Transpiling swift..."
+$BUILD/Debug/swiftkotlin constructors.swift --output $BUILD/kt/constructors.kt
+
+echo "Compiling kotlin..."
+kotlinc hello.kt $BUILD/kt/constructors.kt -include-runtime -d $BUILD/jar/test.jar
+
+echo "Running jar..."
+java -Xverify:all -jar $BUILD/jar/test.jar

--- a/IntegrationTest/constructors.swift
+++ b/IntegrationTest/constructors.swift
@@ -26,5 +26,14 @@ open class SomeError : BaseError
 		super.init(message: message, cause: "")
 	}
 
+	public init(_ anonparam: Int)
+	{
+		super.init(message: "\(anonparam)", cause: "")
+	}
+
 }
 
+public func someFunc(_ foo: String)
+{
+	print("ok: \(foo)")
+}

--- a/IntegrationTest/constructors.swift
+++ b/IntegrationTest/constructors.swift
@@ -1,0 +1,30 @@
+
+
+open class BaseError
+{
+	let message: String
+	let cause: String
+
+	public init(message: String, cause: String)
+	{
+		self.message = message
+		self.cause = cause
+	}
+}
+
+open class SomeError : BaseError
+{
+
+
+	public convenience init()
+	{
+		self.init(message: "hello")
+	}
+
+	public init(message: String)
+	{
+		super.init(message: message, cause: "")
+	}
+
+}
+

--- a/IntegrationTest/hello.kt
+++ b/IntegrationTest/hello.kt
@@ -4,6 +4,9 @@ fun main(args: Array<String>) {
     val e = SomeError()
     println("ok: constructors ${e.message}")
 
+    val e2 = SomeError(42)
+    println("ok: constructor with anon param ${e2.message}")
 
+    someFunc("anon param")
 }
 

--- a/IntegrationTest/hello.kt
+++ b/IntegrationTest/hello.kt
@@ -1,0 +1,9 @@
+fun main(args: Array<String>) {
+    println("Hello, World!")
+
+    val e = SomeError()
+    println("ok: constructors ${e.message}")
+
+
+}
+

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework.xcodeproj/project.pbxproj
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework.xcodeproj/project.pbxproj
@@ -105,6 +105,11 @@
 		78F032D41D86C15400BE709A /* SwiftKotlinFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 78F032C91D86C15400BE709A /* SwiftKotlinFramework.framework */; };
 		78F032D91D86C15400BE709A /* SwiftKotlinFrameworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F032D81D86C15400BE709A /* SwiftKotlinFrameworkTests.swift */; };
 		78F032E71D86C1C400BE709A /* SwiftKotlinFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 78F032E51D86C1C400BE709A /* SwiftKotlinFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCE34AFC1EB74AAB00681164 /* ConstructorTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE34AFB1EB74AAB00681164 /* ConstructorTransformer.swift */; };
+		FCE34AFD1EB74B9200681164 /* ConstructorTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE34AFB1EB74AAB00681164 /* ConstructorTransformer.swift */; };
+		FCE34AFE1EB74B9300681164 /* ConstructorTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE34AFB1EB74AAB00681164 /* ConstructorTransformer.swift */; };
+		FCE34AFF1EB74B9300681164 /* ConstructorTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE34AFB1EB74AAB00681164 /* ConstructorTransformer.swift */; };
+		FCE34B001EB74B9400681164 /* ConstructorTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE34AFB1EB74AAB00681164 /* ConstructorTransformer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -193,6 +198,7 @@
 		78F032DA1D86C15400BE709A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		78F032E41D86C1C400BE709A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		78F032E51D86C1C400BE709A /* SwiftKotlinFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftKotlinFramework.h; sourceTree = "<group>"; };
+		FCE34AFB1EB74AAB00681164 /* ConstructorTransformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstructorTransformer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -318,11 +324,12 @@
 		78DC1FBA1D897FED009E0283 /* Transformers */ = {
 			isa = PBXGroup;
 			children = (
+				FCE34AFB1EB74AAB00681164 /* ConstructorTransformer.swift */,
 				78E279711DC8D8DA002A62BF /* ControlFlowTransformer.swift */,
 				7868A8B41DCCAABC006F4DDB /* ExtensionTransformer.swift */,
-				78A7E5B41DB8E0C900D77182 /* KeywordReplacementTransformer.swift */,
 				787D80581E2A99B90094747C /* FoundationTypeTransformer.swift */,
 				78A7E5B91DB8FBC300D77182 /* FunctionParametersTransformer.swift */,
+				78A7E5B41DB8E0C900D77182 /* KeywordReplacementTransformer.swift */,
 				784A9EFB1DCB53FE00FFAE7D /* PropertyTransformer.swift */,
 				7868A8B81DCCAF28006F4DDB /* StaticTransformer.swift */,
 				787D80601E2A9CDD0094747C /* StringInterpolatorTransformer.swift */,
@@ -613,6 +620,7 @@
 				784A9EEB1DCA104200FFAE7D /* ControlFlowTransformer.swift in Sources */,
 				7868A8BB1DCCAF28006F4DDB /* StaticTransformer.swift in Sources */,
 				784A9EEE1DCA104A00FFAE7D /* SwiftKotlin.swift in Sources */,
+				FCE34AFE1EB74B9300681164 /* ConstructorTransformer.swift in Sources */,
 				784A9EEA1DCA103D00FFAE7D /* NSRangeExtensions.swift in Sources */,
 				7868A89C1DCC920C006F4DDB /* TokenizerExtensions.swift in Sources */,
 				784A9EF01DCA104E00FFAE7D /* Tokenizer.swift in Sources */,
@@ -628,6 +636,7 @@
 			files = (
 				7878597D1DD339700036D592 /* PropertyTransformer.swift in Sources */,
 				787496581DD3342F00FA12AD /* ViewController.swift in Sources */,
+				FCE34AFF1EB74B9300681164 /* ConstructorTransformer.swift in Sources */,
 				787859891DD339750036D592 /* TokenizerExtensions.swift in Sources */,
 				787859871DD339750036D592 /* FormatterExtensions.swift in Sources */,
 				787D80641E2A9CE00094747C /* StringInterpolatorTransformer.swift in Sources */,
@@ -660,6 +669,7 @@
 				787859821DD339700036D592 /* KeywordReplacementTransformer.swift in Sources */,
 				787859861DD339700036D592 /* StructTransformer.swift in Sources */,
 				787859851DD339700036D592 /* StaticTransformer.swift in Sources */,
+				FCE34B001EB74B9400681164 /* ConstructorTransformer.swift in Sources */,
 				787859811DD339700036D592 /* ExtensionTransformer.swift in Sources */,
 				7878598A1DD339760036D592 /* FormatterExtensions.swift in Sources */,
 				7878598B1DD339760036D592 /* NSRangeExtensions.swift in Sources */,
@@ -673,6 +683,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FCE34AFC1EB74AAB00681164 /* ConstructorTransformer.swift in Sources */,
 				7874964C1DD32DE400FA12AD /* StructTransformer.swift in Sources */,
 				78A7E5C01DB9093A00D77182 /* NSRangeExtensions.swift in Sources */,
 				7868A8B91DCCAF28006F4DDB /* StaticTransformer.swift in Sources */,
@@ -713,6 +724,7 @@
 				7868A89B1DCC920C006F4DDB /* TokenizerExtensions.swift in Sources */,
 				7868A8AB1DCC9BA0006F4DDB /* MemoryManagementTransformerTests.swift in Sources */,
 				784A9EFD1DCB53FE00FFAE7D /* PropertyTransformer.swift in Sources */,
+				FCE34AFD1EB74B9200681164 /* ConstructorTransformer.swift in Sources */,
 				78A7E5C11DB9093A00D77182 /* NSRangeExtensions.swift in Sources */,
 				7868A8B11DCC9C66006F4DDB /* StringDifference.swift in Sources */,
 				7868A8AD1DCC9BA0006F4DDB /* PropertyTransformerTests.swift in Sources */,

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework.xcodeproj/xcshareddata/xcschemes/SwiftKotlinFramework.xcscheme
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework.xcodeproj/xcshareddata/xcschemes/SwiftKotlinFramework.xcscheme
@@ -40,9 +40,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "ConstructorTransformerTests">
-               </Test>
-               <Test
                   Identifier = "ControlFlowTransformerTests/testGuardMultipleDeclaration()">
                </Test>
                <Test

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework/Extensions/FormatterExtensions.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework/Extensions/FormatterExtensions.swift
@@ -71,5 +71,13 @@ extension Formatter {
         return ClosedRange<Int>(uncheckedBounds: (bodyStartIndex, tokenIndex))
     }
     
-    
+    func print() {
+        var index = 0
+        while index < self.tokens.count {
+            let t = self.token(at: index)
+            Swift.print("\(t)")
+            index = index + 1
+        }
+        
+    }
 }

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework/Extensions/FormatterExtensions.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework/Extensions/FormatterExtensions.swift
@@ -34,43 +34,42 @@ extension Formatter {
         guard !(token(at: index)?.isSpace ?? false) else { return }
         insertToken(.space(" "), at: index)
     }
-    
-    extension Formatter {
+
         
-        /// Finds the next matched pair of { } after the given index. Indices are inclusive.
-        func nextBlockScope(after index: Int) -> ClosedRange<Int>?
-        {
-            return nextScope(after: index, start: .startOfScope("{"), end: .endOfScope("}"))
-        }
-        
-        /// Finds the next matched pair of ( ) after the given index. Indices are inclusive.
-        func nextBracketScope(after index: Int) -> ClosedRange<Int>?
-        {
-            return nextScope(after: index, start: .startOfScope("("), end: .endOfScope(")"))
-        }
-        
-        /// Finds the next matched pair of { } after the given index. Indices are inclusive.
-        func nextScope(after index: Int, start: Token, end: Token) -> ClosedRange<Int>?
-        {
-            
-            guard let bodyStartIndex = self.index(of: start, after: index) else { return nil }
-            
-            var scopeCount = 1
-            var tokenIndex = bodyStartIndex
-            repeat {
-                tokenIndex += 1
-                guard let token = self.token(at: tokenIndex) else { return nil }
-                
-                if token == end {
-                    scopeCount -= 1
-                }
-                else if token == start {
-                    scopeCount += 1
-                }
-            } while  scopeCount > 0
-            
-            return ClosedRange<Int>(uncheckedBounds: (bodyStartIndex, tokenIndex))
-        }
+    /// Finds the next matched pair of { } after the given index. Indices are inclusive.
+    public func nextBlockScope(after index: Int) -> ClosedRange<Int>?
+    {
+        return nextScope(after: index, start: .startOfScope("{"), end: .endOfScope("}"))
     }
+    
+    /// Finds the next matched pair of ( ) after the given index. Indices are inclusive.
+    public func nextBracketScope(after index: Int) -> ClosedRange<Int>?
+    {
+        return nextScope(after: index, start: .startOfScope("("), end: .endOfScope(")"))
+    }
+    
+    /// Finds the next matched pair of { } after the given index. Indices are inclusive.
+    public func nextScope(after index: Int, start: Token, end: Token) -> ClosedRange<Int>?
+    {
+        
+        guard let bodyStartIndex = self.index(of: start, after: index) else { return nil }
+        
+        var scopeCount = 1
+        var tokenIndex = bodyStartIndex
+        repeat {
+            tokenIndex += 1
+            guard let token = self.token(at: tokenIndex) else { return nil }
+            
+            if token == end {
+                scopeCount -= 1
+            }
+            else if token == start {
+                scopeCount += 1
+            }
+        } while  scopeCount > 0
+        
+        return ClosedRange<Int>(uncheckedBounds: (bodyStartIndex, tokenIndex))
+    }
+    
     
 }

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework/Extensions/FormatterExtensions.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework/Extensions/FormatterExtensions.swift
@@ -35,4 +35,42 @@ extension Formatter {
         insertToken(.space(" "), at: index)
     }
     
+    extension Formatter {
+        
+        /// Finds the next matched pair of { } after the given index. Indices are inclusive.
+        func nextBlockScope(after index: Int) -> ClosedRange<Int>?
+        {
+            return nextScope(after: index, start: .startOfScope("{"), end: .endOfScope("}"))
+        }
+        
+        /// Finds the next matched pair of ( ) after the given index. Indices are inclusive.
+        func nextBracketScope(after index: Int) -> ClosedRange<Int>?
+        {
+            return nextScope(after: index, start: .startOfScope("("), end: .endOfScope(")"))
+        }
+        
+        /// Finds the next matched pair of { } after the given index. Indices are inclusive.
+        func nextScope(after index: Int, start: Token, end: Token) -> ClosedRange<Int>?
+        {
+            
+            guard let bodyStartIndex = self.index(of: start, after: index) else { return nil }
+            
+            var scopeCount = 1
+            var tokenIndex = bodyStartIndex
+            repeat {
+                tokenIndex += 1
+                guard let token = self.token(at: tokenIndex) else { return nil }
+                
+                if token == end {
+                    scopeCount -= 1
+                }
+                else if token == start {
+                    scopeCount += 1
+                }
+            } while  scopeCount > 0
+            
+            return ClosedRange<Int>(uncheckedBounds: (bodyStartIndex, tokenIndex))
+        }
+    }
+    
 }

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework/SwiftKotlin.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework/SwiftKotlin.swift
@@ -22,6 +22,7 @@ class SwiftKotlin {
     convenience init() {
         self.init(transformers: [
                 FunctionParametersTransformer(),
+                ConstructorTransformer(), 
                 ControlFlowTransformer(),
                 PropertyTransformer(),
                 StaticTransformer(),

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework/Transformers/ConstructorTransformer.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework/Transformers/ConstructorTransformer.swift
@@ -1,0 +1,121 @@
+//
+//  ConstructorTransformer.swift
+//  SwiftKotlinFramework
+//
+//  Created by Jon Nermut on 1/05/2017.
+//  Copyright © 2017 Angel G. Olloqui. All rights reserved.
+//
+
+import Foundation
+
+
+
+class ConstructorTransformer: Transformer {
+    
+
+    
+    func transform(formatter: Formatter) throws {
+        print(formatter)
+        
+        transformInitKeyword(formatter)
+    }
+    
+    func transformInitKeyword(_ formatter: Formatter) {
+
+        formatter.forEach(.keyword("init")) {
+            (i, token) in
+            
+            // basic keyword replacement
+            formatter.replaceToken(at: i, with: .keyword("constructor"))
+            
+            self.replaceDelegateConstructorCalls(formatter, i: i)
+            
+            self.removeConvenienceAndRequired(formatter, i: i)
+        }
+    
+    }
+    
+    func replaceDelegateConstructorCalls(_ formatter: Formatter, i: Int) {
+        
+        let constructorParamsRange = formatter.nextBracketScope(after: i)
+        
+        // find the {} scope of the init
+        if let bodyScope = formatter.nextBlockScope(after: i)
+        {
+            for bodyIndex in bodyScope.lowerBound..<bodyScope.upperBound
+            {
+                if let token0 = formatter.token(at: bodyIndex),
+                    let token1 = formatter.token(at: bodyIndex + 1),
+                    let token2 = formatter.token(at: bodyIndex + 2)
+                {
+                    if ( token0 == .identifier("super") || token0 == .identifier("self") )
+                        && token1 == .symbol(".", .infix)
+                        && token2 == .identifier("init")
+                    {
+                        var delegateToken = token0
+                        if delegateToken == .identifier("self")
+                        {
+                            delegateToken = .identifier("this")
+                        }
+                        
+                        if let paramRange = formatter.nextBracketScope(after: bodyIndex)
+                        {
+                            var newTokens: [Token] = [.space(" "), .symbol(":", .infix), .space(" "), delegateToken]
+                            for i in paramRange.lowerBound...paramRange.upperBound
+                            {
+                                var t = formatter.tokens[i]
+                                if t == .delimiter(":")
+                                {
+                                    // replace x:y call syntax with x=y
+                                    t = .symbol("=", .infix)
+                                }
+                                newTokens.append( t )
+                            }
+                            
+                            
+                            formatter.removeTokens(inRange: bodyIndex...paramRange.upperBound)
+                            
+                            if let cpr = constructorParamsRange
+                            {
+                                formatter.insertTokens(newTokens, at: cpr.upperBound + 1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    func removeConvenienceAndRequired(_ formatter: Formatter, i: Int) {
+        
+        // remove `convenience` and `required` keywords (which are identifiers by the formatter)
+        // do this last as we remove tokens before the init()
+        
+        let startOfLine = formatter.startOfLine(at: i)
+        
+        for n in (startOfLine..<i).reversed()
+        {
+            let t =  formatter.token(at: n)
+            if t == .identifier("required") || t == .identifier("convenience")
+            {
+                formatter.removeToken(at: n)
+                formatter.removeSpacingTokens(at: n)
+            }
+        }
+    }
+    
+    /*
+    func print(_ formatter: Formatter) {
+        var index = 0
+        while index < formatter.tokens.count {
+            let t = formatter.token(at: index)
+            Swift.print(t.debugDescription)
+            index = index + 1
+        }
+        
+    }
+    */
+
+    
+    
+}

--- a/Source/SwiftKotlinFramework/SwiftKotlinFramework/Transformers/ConstructorTransformer.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFramework/Transformers/ConstructorTransformer.swift
@@ -15,9 +15,11 @@ class ConstructorTransformer: Transformer {
 
     
     func transform(formatter: Formatter) throws {
-        print(formatter)
+        //formatter.print()
         
         transformInitKeyword(formatter)
+        
+        
     }
     
     func transformInitKeyword(_ formatter: Formatter) {
@@ -69,18 +71,40 @@ class ConstructorTransformer: Transformer {
                                     // replace x:y call syntax with x=y
                                     t = .symbol("=", .infix)
                                 }
+
                                 newTokens.append( t )
                             }
                             
                             
                             formatter.removeTokens(inRange: bodyIndex...paramRange.upperBound)
                             
+                            
+                            
                             if let cpr = constructorParamsRange
                             {
                                 formatter.insertTokens(newTokens, at: cpr.upperBound + 1)
+                                
                             }
+                            
+
                         }
                     }
+                }
+            }
+            
+            
+        }
+        
+        if let cpr = constructorParamsRange
+        {
+            // remove anon params
+            for i in cpr.lowerBound..<cpr.upperBound
+            {
+                let t = formatter.tokens[i]
+                if t == .identifier("_")
+                {
+                    formatter.removeToken(at: i)
+                    formatter.removeSpacingTokens(at: i)
                 }
             }
         }
@@ -104,17 +128,6 @@ class ConstructorTransformer: Transformer {
         }
     }
     
-    /*
-    func print(_ formatter: Formatter) {
-        var index = 0
-        while index < formatter.tokens.count {
-            let t = formatter.token(at: index)
-            Swift.print(t.debugDescription)
-            index = index + 1
-        }
-        
-    }
-    */
 
     
     

--- a/Source/SwiftKotlinFramework/SwiftKotlinFrameworkTests/Transformers/ConstructorTransformerTests.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFrameworkTests/Transformers/ConstructorTransformerTests.swift
@@ -26,6 +26,14 @@ class ConstructorTransformerTests: XCTestCase {
         AssertTranslateEquals(translate, kotlin)
     }
     
+    func testConstructorWithAnonParam() {
+        let swift = "init(_ foo: bar) {}"
+        let kotlin = "constructor(foo: bar) {}"
+        
+        let translate = try? transformer.translate(content: swift)
+        AssertTranslateEquals(translate, kotlin)
+    }
+    
     func testConvenienceAndRequired() {
         let swift = "public convenience init() {}\n" +
                     "required public init() {}\n" +

--- a/Source/SwiftKotlinFramework/SwiftKotlinFrameworkTests/Transformers/ConstructorTransformerTests.swift
+++ b/Source/SwiftKotlinFramework/SwiftKotlinFrameworkTests/Transformers/ConstructorTransformerTests.swift
@@ -10,18 +10,55 @@ import XCTest
 
 class ConstructorTransformerTests: XCTestCase {
 
+    
+    var transformer: ConstructorTransformer!
+    
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        transformer = ConstructorTransformer()
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
+    func testMostBasicConstructor() {
+        let swift = "init() {}"
+        let kotlin = "constructor() {}"
+        
+        let translate = try? transformer.translate(content: swift)
+        AssertTranslateEquals(translate, kotlin)
     }
     
-    func testsNotImplemented() {
-        XCTFail()
+    func testConvenienceAndRequired() {
+        let swift = "public convenience init() {}\n" +
+                    "required public init() {}\n" +
+                    "required convenience init() {}"
+        let kotlin = "public constructor() {}\n" +
+                    "public constructor() {}\n" +
+                    "constructor() {}"
+        
+        let translate = try? transformer.translate(content: swift)
+        AssertTranslateEquals(translate, kotlin)
+    }
+    
+    func testSuperInit() {
+        let swift = "init() { super.init() }\n" +
+                    "init() { super.init(foo) }\n" +
+                    "init() { super.init(foo: bar) }"
+        let kotlin = "constructor() : super() {  }\n" +
+                    "constructor() : super(foo) {  }\n" +  // param transformation should be done be FunctionParameterTransformer
+                    "constructor() : super(foo= bar) {  }"
+        
+        let translate = try? transformer.translate(content: swift)
+        AssertTranslateEquals(translate, kotlin)
     }
 
+    func testSelfInit() {
+        let swift = "init() { self.init() }\n" +
+                    "init() { self.init(foo) }\n" +
+                    "init() { self.init(foo: bar) }"
+        let kotlin = "constructor() : this() {  }\n" +
+                    "constructor() : this(foo) {  }\n" +  // param transformation should be done be FunctionParameterTransformer
+                    "constructor() : this(foo= bar) {  }"
+        
+        let translate = try? transformer.translate(content: swift)
+        AssertTranslateEquals(translate, kotlin)
+    }
 }


### PR DESCRIPTION
Implements the basics of swift init constructors converted to kotlin secondary constructors. The whole primary constructor in kotlin doesn't really match, so just ignore them. Also converts delegations to super.init and self.init, and removes the `convenience` and `required` keywords.