### PR TITLE
add colors to token for dark mode cases, fixes #85

### DIFF
--- a/Sources/SwiftKotlinApp/ViewController.swift
+++ b/Sources/SwiftKotlinApp/ViewController.swift
@@ -136,7 +136,12 @@ extension Token {
             return [NSAttributedString.Key.foregroundColor: NSColor(red: 0, green: 116.0/255.0, blue: 0, alpha: 1)]
             
         default:
-            return [:]
+            if #available(OSX 10.14, *)
+            {
+                return [NSAttributedString.Key.foregroundColor: NSApp.mainWindow?.effectiveAppearance.name == .darkAqua ? NSColor.white : NSColor.black]
+            } else {
+                return [:]
+            }
         }
     }
     


### PR DESCRIPTION
Instead of returning default colors, return white when in Dark Mode, and black when not.

https://github.com/angelolloqui/SwiftKotlin/issues/85
